### PR TITLE
Change device schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Device Identification Data
 
-This project contains data designed to be consumed by [Melanite](https://github.com/bbc/melanite), and used by [Matterhorn](https://github.com/bbc/matterhorn)
+This project contains data designed to be consumed by [Melanite](https://github.com/bbc/melanite), and used by [Matterhorn](https://github.com/bbc/matterhorn).
 
 ## Development
 

--- a/scripts/get-devices.js
+++ b/scripts/get-devices.js
@@ -8,7 +8,7 @@ function getDevices (directory) {
 
     glob(directory, (err, files) => {
       files.forEach(file => {
-        const contents = JSON.parse(fs.readFileSync(file, 'utf-8'))
+        let contents = JSON.parse(fs.readFileSync(file, 'utf-8'))
         const device = path.basename(file, '.json').split('-')
         contents.brand = device[0]
         contents.model = device[1]

--- a/scripts/get-devices.js
+++ b/scripts/get-devices.js
@@ -4,13 +4,15 @@ const fs = require('fs')
 
 function getDevices (directory) {
   return new Promise(resolve => {
-    let devices = {}
+    let devices = []
 
     glob(directory, (err, files) => {
       files.forEach(file => {
-        const contents = fs.readFileSync(file, 'utf-8')
-        const device = path.basename(file, '.json')
-        devices[device] = JSON.parse(contents)
+        const contents = JSON.parse(fs.readFileSync(file, 'utf-8'))
+        const device = path.basename(file, '.json').split('-')
+        contents.brand = device[0]
+        contents.model = device[1]
+        devices.push(contents)
       })
 
       resolve(devices)

--- a/scripts/get-devices.js
+++ b/scripts/get-devices.js
@@ -1,6 +1,5 @@
 const glob = require('glob')
 const path = require('path')
-const fs = require('fs')
 
 function getDevices (directory) {
   return new Promise(resolve => {

--- a/scripts/get-devices.js
+++ b/scripts/get-devices.js
@@ -8,7 +8,7 @@ function getDevices (directory) {
 
     glob(directory, (err, files) => {
       files.forEach(file => {
-        let contents = JSON.parse(fs.readFileSync(file, 'utf-8'))
+        let contents = require(`../${file}`)
         const device = path.basename(file, '.json').split('-')
         contents.brand = device[0]
         contents.model = device[1]

--- a/scripts/test-schema.js
+++ b/scripts/test-schema.js
@@ -2,6 +2,8 @@ const joi = require('joi')
 
 const schemaString = joi.string().regex(/^[-_,;+ =\/\.a-zA-Z0-9\(\)]+$/g)
 const schema = joi.object({
+  brand: joi.string().required(),
+  model: joi.string().required(),
   fuzzy: schemaString.allow('').required(),
   invariants: joi.array().items(schemaString).required(),
   disallowed: joi.array().items(schemaString).required()


### PR DESCRIPTION
This makes the build process add 'brand' and 'model' keys into the matcher for each device.

```
{
  'google-chrome': {
    invariants: []
    disallowed: []
    fuzzy: ''
  },
  'something-else' : {
    ...
  }
}
```

=>

```
[{
  brand: 'google',
  model: 'chrome',
  invariants: []
  disallowed: []
  fuzzy: ''
}, {
  brand: 'something',
  model: 'else',
  ...
}]
```