### PR TITLE
Check before commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,37 @@ Install dependencies:
 npm install
 ```
 
-### Test
+## Test
 
 To check the data against the schema provided, run:
 ```
 npm test
 ```
 
-#### Matcher testing
+### Matcher Testing Tool
+
+A build job [check-device-matchers](https://jenkins.connected-tv.tools.bbc.co.uk/job/check-device-matcher/build) has been provided which allows you to enter in required information about a matcher, and then run the matcher tests in this context. This tool can help you test new matchers before committing to creating files and modifying repos.
+
+Fields are as follows:
+
+| Key | Description |
+| --- | ----------- |
+| BRAND | Brand to be associated with user-agent and matcher |
+| MODEL | Model to be associated with user-agent and matcher |
+| USER_AGENTS | Newline separated list of example user-agents for a new device |
+| INVARIANTS | Comma separated list of invariant strings - strings that MUST appear in the user-agent for a match. |
+| DISALLOWED | Comma separated list of disallowed strings - strings that MUST NOT appear in the user-agent for a match. |
+| FUZZY_MATCHER | An example user-agent to match against |
+| TYPE | The type of the device for iPlayer RW to identify; probably going to be "TV" if its a TAP device. |
+
+**Note:** If any of these are set in your local environment then tests may not run as expected.
+
+**See:** https://jenkins.connected-tv.tools.bbc.co.uk/job/check-device-matcher/build
+
+
+
+### Local Matcher Testing
+
 To run only the matcher tests, run:
 ```
 npm run test:matcher

--- a/tests/matcher-validation.js
+++ b/tests/matcher-validation.js
@@ -19,14 +19,19 @@ const localType = process.env.TYPE
 
 function addLocalDevice () {
   if (brand && model && localFuzzyMatcher && localType) {
-    devices.push({
+    let localDevice = {
       brand,
       model,
       invariants: (localInvariants || '').split(','),
       fuzzy: localFuzzyMatcher,
       disallowed: (localDisallowed || '').split(','),
       type: localType
-    })
+    }
+
+    console.log('Creating local device:')
+    console.log(JSON.stringify(localDevice, null, 2))
+
+    devices.push(localDevice)
   }
 }
 

--- a/tests/matcher-validation.js
+++ b/tests/matcher-validation.js
@@ -222,9 +222,16 @@ function summarise (results) {
 
 function addLocalUserAgent (userAgents) {
   if (brand && model && localUserAgents) {
-    let newEntries = localUserAgents.trim().split(NL).map((userAgent) => {
-      return `"${brand}","${model}","${userAgent}"`
-    })
+    let newEntries = localUserAgents.trim()
+      .split(NL)
+      .filter((line) => line.trim())
+      .map((userAgent) => {
+        return `"${brand}","${model}","${userAgent}"`
+      })
+    if (newEntries.length) {
+      console.log('Using custom user agents:')
+      console.log(newEntries.join(NL))
+    }
     return userAgents.trim() + NL + newEntries.join(NL)
   }
   return userAgents

--- a/tests/matcher-validation.js
+++ b/tests/matcher-validation.js
@@ -22,9 +22,9 @@ function addLocalDevice () {
     let localDevice = {
       brand,
       model,
-      invariants: (localInvariants || '').split(','),
+      invariants: localInvariants ? localInvariants.split(',') : [],
       fuzzy: localFuzzyMatcher,
-      disallowed: (localDisallowed || '').split(','),
+      disallowed: localDisallowed ? localDisallowed.split(',') : [],
       type: localType
     }
 

--- a/tests/matcher-validation.js
+++ b/tests/matcher-validation.js
@@ -117,8 +117,11 @@ function testLine (line) {
     result.message = `No local device found for ${brand}-${model}`
   }
 
-  if (count % 100 === 1) {
+  if (count % 100 === 99) {
     process.stdout.write('.')
+    if (count % 1000 === 999) {
+      process.stdout.write(NL)
+    }
   }
   count++
 


### PR DESCRIPTION
Allow local environment variables to be set in order to run tests against a new device matcher without creating additional files. Formats input data suitably for importing into **device-identification-data** and **tvp-user-agents**.
