### PR TITLE
OPS-229689: Add LG 2018_generic

### DIFF
--- a/devices/lg/lg-2018_generic.json
+++ b/devices/lg/lg-2018_generic.json
@@ -1,0 +1,10 @@
+[
+  {
+    "invariants": [
+      "Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.34 Safari/537.36 WebAppManager"
+    ],
+    "disallowed": [],
+    "fuzzy": "Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.34 Safari/537.36 WebAppManager",
+    "type": "tv"
+  }
+]


### PR DESCRIPTION
Temporary user agent for LG devices